### PR TITLE
docs(README): add dao website meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # `community`
 
 A repository for storing community-related information like meeting notes.
+
+- [Developer DAO Website 2021-09-13](./meetings/2021/20210913-website.md)


### PR DESCRIPTION
Added website meeting to the `README`. Figured we can just list all of the meeting notes there to act as an index for the time being.