### PR TITLE
Correct Mirror.xyz name and link

### DIFF
--- a/meetings/2021/20210913-website.md
+++ b/meetings/2021/20210913-website.md
@@ -90,7 +90,7 @@
 
 - [Medium.com](https://medium.com) was presented as an option to blog on
 - [Dev.to](https://dev.to) a more dev focused blogging platform
-- [Mirrow.xyz](https://mirrow.xyz) a more web3 focus blogging platform
+- [Mirror.xyz](https://mirror.xyz) a more web3 focus blogging platform
 - [Hashnode](https://hashnode.com) another blog platform
 - [Ghost](https://ghost.org) a possible solution for self hosting
 - Undecided was how the submissions process would work, if any, and if there would be a moderation process put in place as well


### PR DESCRIPTION
Mirror was being referred to as Mirrow